### PR TITLE
PR: Enhance Game Logic and Test Coverage

### DIFF
--- a/game/draw_phase.py
+++ b/game/draw_phase.py
@@ -1,8 +1,9 @@
 import logging
 from typing import List
 
-from .player import Player
 from .deck import Deck
+from .player import Player
+
 
 def handle_draw_phase(players: List[Player], deck: Deck) -> None:
     """
@@ -11,54 +12,78 @@ def handle_draw_phase(players: List[Player], deck: Deck) -> None:
     Each non-folded player gets one opportunity to discard 0-5 cards and draw
     replacements. AI players use decide_draw() to choose discards, while non-AI
     players keep their current hand.
-    
+
     Args:
         players: List of active players
         deck: Current deck of cards
-        
+
     Side Effects:
         - Updates player hands
         - Logs draw actions
     """
     logging.info("\n--- Draw Phase ---")
     discarded_cards = []
-    
+
     for player in players:
         if player.folded:
             continue
-            
+
         # Log current hand
         logging.info(f"\n{player.name}'s hand: {player.hand.show()}")
-        
+
         # Get discards if player has a decision method
         if hasattr(player, "decide_draw"):
             discards = player.decide_draw()
-            
-            if discards and len(discards) <= 5:
+
+            # Validate discards
+            if not all(0 <= idx < len(player.hand.cards) for idx in discards):
+                logging.warning(
+                    f"{player.name} provided invalid discard indexes: {discards}"
+                )
+                logging.info("Keeping current hand")
+                continue
+
+            if len(discards) > 5:
+                logging.warning(f"{player.name} attempted to discard more than 5 cards")
+                logging.info("Keeping current hand")
+                continue
+
+            if discards:
                 # Remove discarded cards and track them
                 discarded = []
                 for idx in sorted(discards, reverse=True):
                     card = player.hand.cards.pop(idx)
                     discarded.append(card)
                 discarded_cards.extend(reversed(discarded))
-                
+
                 # Check if we need to reshuffle
                 if len(deck.cards) < len(discards):
-                    logging.info("Reshuffling discarded cards into deck")
-                    deck.cards.extend(discarded_cards)
-                    deck.shuffle()
-                    discarded_cards = []
-                
+                    if discarded_cards:
+                        logging.info("Reshuffling discarded cards into deck")
+                        deck.cards.extend(discarded_cards)
+                        deck.shuffle()
+                        discarded_cards = []
+                    else:
+                        logging.warning(
+                            "Deck is empty and no discarded cards to reshuffle"
+                        )
+                        logging.info("Keeping current hand")
+                        continue
+
                 # Draw new cards
                 new_cards = deck.deal(len(discards))
-                
+
                 # Insert new cards at original positions
                 for i, card in zip(sorted(discards), new_cards):
                     player.hand.cards.insert(i, card)
-                
-                logging.info(f"{player.name} discards {len(discards)} and draws {len(new_cards)}")
+
+                logging.info(
+                    f"{player.name} discards {len(discards)} and draws {len(new_cards)}"
+                )
                 logging.info(f"New hand: {player.hand.show()}")
             else:
-                logging.info("Keeping current hand")
+                logging.info("No cards discarded; keeping current hand")
         else:
-            logging.info("Keeping current hand") 
+            logging.info(
+                "Non-AI player or player without decision method; keeping current hand"
+            )

--- a/game/game.py
+++ b/game/game.py
@@ -373,7 +373,7 @@ class AgenticPoker:
         post_draw.handle_showdown(
             players=self.players,
             initial_chips=initial_chips,
-            pot_manager=self.pot_manager
+            pot_manager=self.pot_manager,
         )
 
     def _log_chip_movements(self, initial_chips: Dict[Player, int]) -> None:

--- a/game/game.py
+++ b/game/game.py
@@ -2,16 +2,12 @@ import logging
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
-
+from . import betting, draw_phase, post_draw, pre_draw
 from .deck import Deck
 from .hand import Hand
 from .player import Player
 from .pot_manager import PotManager
 from .types import SidePot
-from . import betting
-from . import post_draw
-from . import pre_draw
-from . import draw_phase
 
 
 @dataclass

--- a/game/game.py
+++ b/game/game.py
@@ -371,7 +371,9 @@ class AgenticPoker:
 
         # Handle showdown using post_draw module
         post_draw.handle_showdown(
-            players=self.players, pot=self.pot, initial_chips=initial_chips
+            players=self.players,
+            initial_chips=initial_chips,
+            pot_manager=self.pot_manager
         )
 
     def _log_chip_movements(self, initial_chips: Dict[Player, int]) -> None:

--- a/game/pot_manager.py
+++ b/game/pot_manager.py
@@ -144,3 +144,21 @@ class PotManager:
         for i, pot in enumerate(self.get_side_pots_view(), 1):
             players_str = ", ".join(pot["eligible_players"])
             logger.info(f"  Pot {i}: ${pot['amount']} (Eligible: {players_str})")
+
+    def set_pots(self, main_pot: int, side_pots: Optional[List[SidePot]] = None) -> None:
+        """
+        Set the main pot and side pots directly.
+
+        Args:
+            main_pot: Amount for the main pot
+            side_pots: Optional list of side pots to set
+
+        Side Effects:
+            - Updates the main pot amount
+            - Updates the side pots list
+        """
+        if main_pot < 0:
+            raise ValueError("Main pot cannot be negative")
+        
+        self.pot = main_pot
+        self.side_pots = side_pots

--- a/game/pre_draw.py
+++ b/game/pre_draw.py
@@ -1,17 +1,18 @@
 import logging
 from typing import List, Optional, Tuple
 
-from .player import Player
-from .types import SidePot
 from . import betting
+from .player import Player
 from .pot_manager import PotManager
+from .types import SidePot
+
 
 def handle_pre_draw_betting(
     players: List[Player],
     pot: int,
     dealer_index: int,
     game_state: dict,
-    pot_manager: PotManager
+    pot_manager: PotManager,
 ) -> Tuple[int, Optional[List[SidePot]], bool]:
     """
     Handle the pre-draw betting round.
@@ -37,41 +38,54 @@ def handle_pre_draw_betting(
         pot=pot,
         dealer_index=dealer_index,
         game_state=game_state,
-        phase="pre-draw"
+        phase="pre-draw",
     )
+
+    # Update the pot manager with new values
+    pot_manager.pot = new_pot  # Use direct pot assignment instead of update_main_pot
+    if side_pots:
+        pot_manager.side_pots = side_pots  # Use direct side_pots assignment
 
     # Check if only one player remains
     active_players = [p for p in players if not p.folded]
     should_continue = len(active_players) > 1
 
-    # If only one player remains, award them the pot
+    # If only one player remains, award them the pot (main + side pots)
     if not should_continue:
         winner = active_players[0]
-        winner.chips += new_pot
-        logging.info(f"\n{winner.name} wins ${new_pot} (all others folded pre-draw)")
+        total_payout = new_pot + sum(side_pot.amount for side_pot in (side_pots or []))
+        winner.chips += total_payout
+        logging.info(
+            f"\n{winner.name} wins ${total_payout} (all others folded pre-draw)"
+        )
+        new_pot = 0  # Reset the main pot since it's been awarded
+
+    # Log chip movements after betting round
+    _log_chip_movements(players, game_state)
 
     return new_pot, side_pots, should_continue
+
 
 def _log_chip_movements(players: List[Player], game_state: dict) -> None:
     """
     Log the chip movements from initial state.
-    
+
     Args:
         players: List of players
         game_state: Game state containing initial chip counts
     """
     initial_chips = {
         p.name: next(
-            player["chips"] 
-            for player in game_state["players"] 
+            player["chips"]
+            for player in game_state["players"]
             if player["name"] == p.name
         )
         for p in players
     }
-    
+
     for player in players:
         if player.chips != initial_chips[player.name]:
             net_change = player.chips - initial_chips[player.name]
             logging.info(
                 f"{player.name}: ${initial_chips[player.name]} → ${player.chips} ({net_change:+d})"
-            ) 
+            )

--- a/tests/game/test_draw_phase.py
+++ b/tests/game/test_draw_phase.py
@@ -3,11 +3,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from game.draw_phase import handle_draw_phase
-from game.player import Player
-from game.deck import Deck
-from game.hand import Hand
 from game.card import Card
+from game.deck import Deck
+from game.draw_phase import handle_draw_phase
+from game.hand import Hand
+from game.player import Player
 
 
 @pytest.fixture
@@ -17,10 +17,7 @@ def mock_players():
     for i in range(3):
         player = Player(f"Player{i}", 1000)
         player.hand = Hand()
-        player.hand.add_cards([
-            Card(rank, "Hearts") 
-            for rank in range(2, 7)
-        ])
+        player.hand.add_cards([Card(rank, "Hearts") for rank in range(2, 7)])
         player.folded = False
         players.append(player)
     return players
@@ -38,33 +35,36 @@ def mock_deck():
 def test_handle_draw_phase_no_discards(mock_players, mock_deck, caplog):
     """Test draw phase when no players discard cards."""
     caplog.set_level(logging.INFO)
-    
+
     # None of the players have decide_draw method
     handle_draw_phase(mock_players, mock_deck)
-    
+
     # Check that all players kept their original hands
     for player in mock_players:
         assert len(player.hand.cards) == 5
         assert all(card.suit == "Hearts" for card in player.hand.cards)
-        assert "Keeping current hand" in caplog.text
+        assert (
+            "Non-AI player or player without decision method; keeping current hand"
+            in caplog.text
+        )
 
 
 def test_handle_draw_phase_with_discards(mock_players, mock_deck, caplog):
     """Test draw phase when a player discards cards."""
     caplog.set_level(logging.INFO)
-    
+
     # Set up specific cards in deck for testing
     mock_deck.cards = [Card(suit="Spades", rank="2")]
-    
+
     # Add decide_draw method to first player
     mock_players[0].decide_draw = MagicMock(return_value=[0])  # Discard first card
-    
+
     handle_draw_phase(mock_players, mock_deck)
-    
+
     # Check first player's hand was modified
     assert mock_players[0].hand.cards[0].suit == "Spades"
     assert all(card.suit == "Hearts" for card in mock_players[0].hand.cards[1:])
-    
+
     # Check other players' hands remained unchanged
     for player in mock_players[1:]:
         assert len(player.hand.cards) == 5
@@ -74,17 +74,39 @@ def test_handle_draw_phase_with_discards(mock_players, mock_deck, caplog):
 def test_handle_draw_phase_reshuffle(mock_players, mock_deck, caplog):
     """Test draw phase when deck needs reshuffling."""
     caplog.set_level(logging.INFO)
-    
-    # Set up a nearly empty deck
+
+    # Empty the deck except for one card
     mock_deck.cards = [Card(suit="Spades", rank="2")]
-    
-    # Add decide_draw method to first player
-    mock_players[0].decide_draw = MagicMock(return_value=[0, 1, 2])  # Discard three cards
-    
+
+    # Add decide_draw method to first player to discard 3 cards
+    mock_players[0].decide_draw = MagicMock(return_value=[0, 1, 2])
+    original_cards = mock_players[0].hand.cards.copy()
+
     handle_draw_phase(mock_players, mock_deck)
-    
+
+    # Verify reshuffle behavior
     assert "Reshuffling discarded cards into deck" in caplog.text
-    assert len(mock_players[0].hand.cards) == 5  # Player still gets their cards
+    assert len(mock_players[0].hand.cards) == 5
+
+    # After reshuffling, we can only verify:
+    # 1. The number of cards is correct
+    # 2. Some of the original cards are still in the hand
+    # 3. At least one card from the deck was used
+
+    # Check that at least one Spades card was drawn
+    spades_count = sum(
+        1 for card in mock_players[0].hand.cards if card.suit == "Spades"
+    )
+    assert spades_count > 0, "Should have drawn at least one card from the deck"
+
+    # Check that some original Hearts cards remain
+    hearts_count = sum(
+        1 for card in mock_players[0].hand.cards if card.suit == "Hearts"
+    )
+    assert hearts_count > 0, "Should have kept some original Hearts cards"
+
+    # Verify total cards is still correct
+    assert hearts_count + spades_count == 5, "Total cards should be 5"
 
 
 def test_handle_draw_phase_folded_players(mock_players, mock_deck):
@@ -92,42 +114,69 @@ def test_handle_draw_phase_folded_players(mock_players, mock_deck):
     # Make second player folded
     mock_players[1].folded = True
     mock_players[1].decide_draw = MagicMock()  # Should never be called
-    
+
     handle_draw_phase(mock_players, mock_deck)
-    
+
     mock_players[1].decide_draw.assert_not_called()
 
 
 def test_handle_draw_phase_no_discard_decision(mock_players, mock_deck, caplog):
     """Test draw phase when player decides not to discard."""
     caplog.set_level(logging.INFO)
-    
+
     # Add decide_draw method that returns empty list
     mock_players[0].decide_draw = MagicMock(return_value=[])
     original_hand = mock_players[0].hand.cards.copy()
-    
+
     handle_draw_phase(mock_players, mock_deck)
-    
+
     assert mock_players[0].hand.cards == original_hand
-    assert "Keeping current hand" in caplog.text
+    # Update to match actual log message
+    assert "No cards discarded; keeping current hand" in caplog.text
 
 
 def test_handle_draw_phase_multiple_discards(mock_players, mock_deck):
     """Test draw phase with multiple players discarding."""
     # Set up specific cards in deck
-    mock_deck.cards = [
-        Card(suit="Spades", rank=str(r)) for r in range(2, 5)
-    ]
-    
+    new_cards = [Card(suit="Spades", rank=str(r)) for r in range(2, 5)]
+    mock_deck.cards = new_cards.copy()
+
     # Set up discards for two players
     mock_players[0].decide_draw = MagicMock(return_value=[0])
     mock_players[1].decide_draw = MagicMock(return_value=[1, 2])
-    
+
+    # Store original cards that won't be discarded
+    player0_kept = mock_players[0].hand.cards[1:].copy()
+    player1_kept = [mock_players[1].hand.cards[0]] + mock_players[1].hand.cards[
+        3:
+    ].copy()
+
     handle_draw_phase(mock_players, mock_deck)
-    
-    # Check both players got correct number of new cards
+
+    # Check first player's hand
     assert len(mock_players[0].hand.cards) == 5
+    assert mock_players[0].hand.cards[0] == new_cards[0]  # First new card
+    assert mock_players[0].hand.cards[1:] == player0_kept  # Rest unchanged
+
+    # Check second player's hand
     assert len(mock_players[1].hand.cards) == 5
-    assert mock_players[0].hand.cards[0].suit == "Spades"
-    assert mock_players[1].hand.cards[1].suit == "Spades"
-    assert mock_players[1].hand.cards[2].suit == "Spades" 
+    assert mock_players[1].hand.cards[1] == new_cards[1]  # Second new card
+    assert mock_players[1].hand.cards[2] == new_cards[2]  # Third new card
+    assert mock_players[1].hand.cards[0] == player1_kept[0]  # Unchanged cards
+    assert mock_players[1].hand.cards[3:] == player1_kept[1:]
+
+
+def test_handle_draw_phase_negative_index(mock_players, mock_deck, caplog):
+    """Test draw phase when player provides negative discard indexes."""
+    caplog.set_level(logging.INFO)
+
+    # Add decide_draw method that returns negative index
+    mock_players[0].decide_draw = MagicMock(return_value=[-1])
+    original_hand = mock_players[0].hand.cards.copy()
+
+    handle_draw_phase(mock_players, mock_deck)
+
+    # Check that hand remained unchanged
+    assert mock_players[0].hand.cards == original_hand
+    assert "invalid discard indexes" in caplog.text
+    assert "Keeping current hand" in caplog.text

--- a/tests/game/test_post_draw.py
+++ b/tests/game/test_post_draw.py
@@ -10,7 +10,6 @@ from game.post_draw import (
     _log_chip_movements,
 )
 from game.player import Player
-from game.hand import Hand
 from game.types import SidePot
 
 
@@ -48,17 +47,14 @@ def mock_game_state(mock_players):
 def test_handle_post_draw_betting_simple_case(mock_players, mock_game_state):
     """Test post-draw betting with a simple case (no side pots)."""
     mock_pot_manager = MagicMock()
-    
+
     with patch("game.betting.betting_round") as mock_betting:
         mock_betting.return_value = 150  # Simple pot increase
-        
+
         new_pot, side_pots = handle_post_draw_betting(
-            mock_players,
-            100,
-            mock_game_state,
-            mock_pot_manager
+            mock_players, 100, mock_game_state, mock_pot_manager
         )
-        
+
         assert new_pot == 150
         assert side_pots is None
         mock_betting.assert_called_once_with(mock_players, 100, mock_game_state)
@@ -68,17 +64,14 @@ def test_handle_post_draw_betting_with_side_pots(mock_players, mock_game_state):
     """Test post-draw betting when side pots are created."""
     mock_pot_manager = MagicMock()
     mock_side_pots = [SidePot(amount=50, eligible_players=mock_players[:2])]
-    
+
     with patch("game.betting.betting_round") as mock_betting:
         mock_betting.return_value = (150, mock_side_pots)
-        
+
         new_pot, side_pots = handle_post_draw_betting(
-            mock_players,
-            100,
-            mock_game_state,
-            mock_pot_manager
+            mock_players, 100, mock_game_state, mock_pot_manager
         )
-        
+
         assert new_pot == 150
         assert side_pots == mock_side_pots
 
@@ -89,9 +82,14 @@ def test_handle_showdown_single_winner(mock_players, caplog):
     mock_players[1].folded = True
     mock_players[2].folded = True
     initial_chips = {p: p.chips for p in mock_players}
-    pot = 300
 
-    handle_showdown(mock_players, pot, initial_chips)
+    # Create mock pot manager
+    mock_pot_manager = MagicMock()
+    mock_pot_manager.get_pots.return_value = (300, [])  # main_pot=300, no side pots
+
+    handle_showdown(
+        players=mock_players, initial_chips=initial_chips, pot_manager=mock_pot_manager
+    )
 
     assert mock_players[0].chips == 1300  # Initial 1000 + pot 300
     assert "wins $300 (all others folded)" in caplog.text
@@ -101,19 +99,86 @@ def test_handle_showdown_multiple_winners(mock_players, caplog):
     """Test showdown with multiple players and split pot."""
     caplog.set_level(logging.INFO)
     initial_chips = {p: 1000 for p in mock_players}
-    pot = 300
+
+    # Create mock pot manager
+    mock_pot_manager = MagicMock()
+    mock_pot_manager.get_pots.return_value = (300, [])  # main_pot=300, no side pots
 
     # Mock hands to create a tie
     with patch("game.post_draw._evaluate_hands") as mock_evaluate:
         mock_evaluate.return_value = mock_players[:2]  # First two players tie
-        
-        handle_showdown(mock_players, pot, initial_chips)
-        
+
+        handle_showdown(
+            players=mock_players,
+            initial_chips=initial_chips,
+            pot_manager=mock_pot_manager,
+        )
+
         # Each winner should get half the pot (150 each)
         assert mock_players[0].chips == 1150
         assert mock_players[1].chips == 1150
         assert mock_players[2].chips == 1000
         assert "wins $150" in caplog.text
+
+
+def test_handle_showdown_odd_chips(mock_players, caplog):
+    """Test showdown with odd number of chips to split."""
+    caplog.set_level(logging.INFO)
+    initial_chips = {p: 1000 for p in mock_players}
+
+    # Create mock pot manager with odd pot amount
+    mock_pot_manager = MagicMock()
+    mock_pot_manager.get_pots.return_value = (301, [])  # main_pot=301, no side pots
+
+    # Mock hands to create a tie
+    with patch("game.post_draw._evaluate_hands") as mock_evaluate:
+        mock_evaluate.return_value = mock_players[:2]  # First two players tie
+
+        handle_showdown(
+            players=mock_players,
+            initial_chips=initial_chips,
+            pot_manager=mock_pot_manager,
+        )
+
+        # First player should get 151, second player 150
+        assert mock_players[0].chips == 1151
+        assert mock_players[1].chips == 1150
+        assert mock_players[2].chips == 1000
+
+
+def test_handle_showdown_with_side_pots(mock_players, caplog):
+    """Test showdown with main pot and side pots."""
+    caplog.set_level(logging.INFO)
+    initial_chips = {p: 1000 for p in mock_players}
+
+    # Create mock pot manager with main pot and side pot
+    mock_pot_manager = MagicMock()
+    mock_side_pot = SidePot(amount=100, eligible_players=mock_players[1:])
+    mock_pot_manager.get_pots.return_value = (
+        200,
+        [mock_side_pot],
+    )  # main_pot=200, one side pot
+
+    # Mock hands evaluation
+    with patch("game.post_draw._evaluate_hands") as mock_evaluate:
+        # First evaluation for main pot
+        # Second evaluation for side pot
+        mock_evaluate.side_effect = [
+            [mock_players[0]],  # Player 0 wins main pot
+            [mock_players[1]],  # Player 1 wins side pot
+        ]
+
+        handle_showdown(
+            players=mock_players,
+            initial_chips=initial_chips,
+            pot_manager=mock_pot_manager,
+        )
+
+        assert mock_players[0].chips == 1200  # Initial 1000 + main pot 200
+        assert mock_players[1].chips == 1100  # Initial 1000 + side pot 100
+        assert mock_players[2].chips == 1000  # Unchanged
+        assert "wins $200" in caplog.text
+        assert "wins $100 from side pot" in caplog.text
 
 
 def test_evaluate_hands_single_winner():
@@ -123,12 +188,12 @@ def test_evaluate_hands_single_winner():
         player = Player(f"Player{i}", 1000)
         player.hand = MagicMock()
         players.append(player)
-    
+
     # Set up hand comparisons
     players[0].hand.compare_to = lambda x: 1  # Better than others
     players[1].hand.compare_to = lambda x: -1  # Worse than player 0
     players[2].hand.compare_to = lambda x: -1  # Worse than player 0
-    
+
     winners = _evaluate_hands(players)
     assert len(winners) == 1
     assert winners[0] == players[0]
@@ -141,14 +206,14 @@ def test_evaluate_hands_tie():
         player = Player(f"Player{i}", 1000)
         player.hand = MagicMock()
         players.append(player)
-    
+
     # Set up hand comparisons for a tie
     def compare_to(other):
         return 0  # All hands tie
-    
+
     for player in players:
         player.hand.compare_to = compare_to
-    
+
     winners = _evaluate_hands(players)
     assert len(winners) == 3
     assert set(winners) == set(players)
@@ -157,21 +222,21 @@ def test_evaluate_hands_tie():
 def test_log_chip_movements(mock_players, caplog):
     """Test logging of chip movements."""
     caplog.set_level(logging.INFO)
-    
+
     # Set up initial and final chip counts
     initial_chips = {
         mock_players[0]: 1000,
         mock_players[1]: 1000,
         mock_players[2]: 1000,
     }
-    
+
     # Modify current chips to simulate wins/losses
     mock_players[0].chips = 1200  # Won 200
-    mock_players[1].chips = 800   # Lost 200
+    mock_players[1].chips = 800  # Lost 200
     mock_players[2].chips = 1000  # No change
-    
+
     _log_chip_movements(mock_players, initial_chips)
-    
+
     # Check log messages
     assert "Player0: $1000 → $1200 (+200)" in caplog.text
     assert "Player1: $1000 → $800 (-200)" in caplog.text
@@ -187,10 +252,10 @@ def test_handle_showdown_odd_chips(mock_players, caplog):
     # Mock hands to create a tie
     with patch("game.post_draw._evaluate_hands") as mock_evaluate:
         mock_evaluate.return_value = mock_players[:2]  # First two players tie
-        
+
         handle_showdown(mock_players, pot, initial_chips)
-        
+
         # First player should get 151, second player 150
         assert mock_players[0].chips == 1151
         assert mock_players[1].chips == 1150
-        assert mock_players[2].chips == 1000 
+        assert mock_players[2].chips == 1000

--- a/tests/game/test_pre_draw.py
+++ b/tests/game/test_pre_draw.py
@@ -3,8 +3,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from game.pre_draw import handle_pre_draw_betting, _log_chip_movements
 from game.player import Player
+from game.pre_draw import _log_chip_movements, handle_pre_draw_betting
 from game.types import SidePot
 
 
@@ -41,26 +41,22 @@ def mock_game_state(mock_players):
 def test_handle_pre_draw_betting_all_active(mock_players, mock_game_state):
     """Test pre-draw betting when all players remain active."""
     mock_pot_manager = MagicMock()
-    
+
     with patch("game.betting.handle_betting_round") as mock_betting:
         mock_betting.return_value = (150, None)
-        
+
         new_pot, side_pots, should_continue = handle_pre_draw_betting(
-            mock_players,
-            100,
-            0,
-            mock_game_state,
-            mock_pot_manager
+            mock_players, 100, 0, mock_game_state, mock_pot_manager
         )
-        
+
         mock_betting.assert_called_once_with(
             players=mock_players,
             pot=100,
             dealer_index=0,
             game_state=mock_game_state,
-            phase="pre-draw"
+            phase="pre-draw",
         )
-        
+
         assert new_pot == 150
         assert side_pots is None
         assert should_continue is True
@@ -70,45 +66,41 @@ def test_handle_pre_draw_betting_one_remaining(mock_players, mock_game_state, ca
     """Test pre-draw betting when all but one player folds."""
     caplog.set_level(logging.INFO)
     mock_pot_manager = MagicMock()
-    
+
     # Make all but first player fold
     mock_players[1].folded = True
     mock_players[2].folded = True
-    
+
     with patch("game.betting.handle_betting_round") as mock_betting:
-        mock_betting.return_value = (150, None)
-        
+        # Add a side pot to test total payout calculation
+        mock_side_pots = [SidePot(amount=50, eligible_players=mock_players[:2])]
+        mock_betting.return_value = (150, mock_side_pots)
+
         new_pot, side_pots, should_continue = handle_pre_draw_betting(
-            mock_players,
-            100,
-            0,
-            mock_game_state,
-            mock_pot_manager
+            mock_players, 100, 0, mock_game_state, mock_pot_manager
         )
-        
-        assert new_pot == 150
-        assert side_pots is None
+
+        # Pot should be reset to 0 after awarding
+        assert new_pot == 0
+        assert side_pots == mock_side_pots
         assert should_continue is False
-        assert mock_players[0].chips == 1150  # Initial 1000 + pot 150
-        assert "wins $150 (all others folded pre-draw)" in caplog.text
+        # Player should receive main pot (150) + side pot (50)
+        assert mock_players[0].chips == 1200  # Initial 1000 + total payout 200
+        assert "wins $200 (all others folded pre-draw)" in caplog.text
 
 
 def test_handle_pre_draw_betting_with_side_pots(mock_players, mock_game_state):
     """Test pre-draw betting with side pots."""
     mock_pot_manager = MagicMock()
     mock_side_pots = [SidePot(amount=50, eligible_players=mock_players[:2])]
-    
+
     with patch("game.betting.handle_betting_round") as mock_betting:
         mock_betting.return_value = (150, mock_side_pots)
-        
+
         new_pot, side_pots, should_continue = handle_pre_draw_betting(
-            mock_players,
-            100,
-            0,
-            mock_game_state,
-            mock_pot_manager
+            mock_players, 100, 0, mock_game_state, mock_pot_manager
         )
-        
+
         assert new_pot == 150
         assert side_pots == mock_side_pots
         assert should_continue is True
@@ -117,14 +109,14 @@ def test_handle_pre_draw_betting_with_side_pots(mock_players, mock_game_state):
 def test_log_chip_movements(mock_players, mock_game_state, caplog):
     """Test logging of chip movements."""
     caplog.set_level(logging.INFO)
-    
+
     # Modify current chips to simulate wins/losses
     mock_players[0].chips = 1200  # Won 200
-    mock_players[1].chips = 800   # Lost 200
+    mock_players[1].chips = 800  # Lost 200
     mock_players[2].chips = 1000  # No change
-    
+
     _log_chip_movements(mock_players, mock_game_state)
-    
+
     # Check log messages
     assert "Player0: $1000 → $1200 (+200)" in caplog.text
     assert "Player1: $1000 → $800 (-200)" in caplog.text
@@ -136,25 +128,21 @@ def test_handle_pre_draw_betting_all_in(mock_players, mock_game_state):
     mock_pot_manager = MagicMock()
     mock_side_pots = [
         SidePot(amount=100, eligible_players=mock_players),
-        SidePot(amount=50, eligible_players=mock_players[:2])
+        SidePot(amount=50, eligible_players=mock_players[:2]),
     ]
-    
+
     # Simulate one player being all-in
     mock_players[2].chips = 0
-    
+
     with patch("game.betting.handle_betting_round") as mock_betting:
         mock_betting.return_value = (150, mock_side_pots)
-        
+
         new_pot, side_pots, should_continue = handle_pre_draw_betting(
-            mock_players,
-            100,
-            0,
-            mock_game_state,
-            mock_pot_manager
+            mock_players, 100, 0, mock_game_state, mock_pot_manager
         )
-        
+
         assert new_pot == 150
         assert len(side_pots) == 2
         assert side_pots[0].amount == 100
         assert side_pots[1].amount == 50
-        assert should_continue is True 
+        assert should_continue is True


### PR DESCRIPTION
This PR improves game logic robustness, adds comprehensive test coverage, and implements better error handling across multiple game phases. Key focus areas include draw phase validation, pot management, and showdown mechanics.

## Changes

### 1. Draw Phase Enhancements (`game/draw_phase.py`)
- Added validation for discard indexes
- Improved reshuffling logic when deck is empty
- Enhanced error handling for invalid discards
- Added more detailed logging messages

```python:game/draw_phase.py
# Added validation for discard indexes
if not all(0 <= idx < len(player.hand.cards) for idx in discards):
    logging.warning(f"{player.name} provided invalid discard indexes: {discards}")
    logging.info("Keeping current hand")
    continue

# Enhanced reshuffling logic
if len(deck.cards) < len(discards):
    if discarded_cards:
        logging.info("Reshuffling discarded cards into deck")
        deck.cards.extend(discarded_cards)
        deck.shuffle()
        discarded_cards = []
    else:
        logging.warning("Deck is empty and no discarded cards to reshuffle")
```

### 2. Post-Draw Phase Improvements (`game/post_draw.py`)
- Refactored showdown logic to handle side pots
- Added support for odd chip distribution
- Improved handling of single-player wins
- Enhanced chip movement tracking

```python:game/post_draw.py
def handle_showdown(
    players: List[Player],
    initial_chips: Dict[Player, int],
    pot_manager: "PotManager",
) -> None:
    # Handle single player case first
    if len(active_players) == 1:
        winner = active_players[0]
        pot_amount = int(pot_manager.pot)
        winner.chips += pot_amount
        logging.info(f"{winner.name} wins ${pot_amount} (all others folded)")
        return
```

### 3. Pot Manager Updates (`game/pot_manager.py`)
- Added `set_pots` method for direct pot management
- Improved side pot handling
- Added validation for negative pot values

```python:game/pot_manager.py
def set_pots(self, main_pot: int, side_pots: Optional[List[SidePot]] = None) -> None:
    if main_pot < 0:
        raise ValueError("Main pot cannot be negative")
    
    self.pot = main_pot
    self.side_pots = side_pots
```

### 4. Test Coverage Expansion
- Added comprehensive tests for draw phase edge cases
- Enhanced showdown testing scenarios
- Added tests for pot management
- Improved test coverage for side pot handling

## Documentation
- Added inline documentation for new methods
- Enhanced logging messages for better debugging
- Updated code comments for clarity
