### PR TITLE
PR: Draw Phase Improvements and Bug Fixes

### DIFF
--- a/loggers/draw_logger.py
+++ b/loggers/draw_logger.py
@@ -41,10 +41,10 @@ class DrawLogger:
         logger.error(f"Error in draw phase for {player_name}: {error}")
 
     @staticmethod
-    def log_non_ai_player() -> None:
-        """Log when encountering a non-AI player."""
+    def log_non_ai_player(player_name: str) -> None:
+        """Log when a non-AI player is encountered."""
         logger.info(
-            "Non-AI player or player without decision method; keeping current hand"
+            f"{player_name} is a non-AI player or player without decision method; keeping current hand"
         )
 
     @staticmethod
@@ -73,9 +73,9 @@ class DrawLogger:
         )
 
     @staticmethod
-    def log_keep_hand(player_name: str, explicit_decision: bool = True) -> None:
+    def log_keep_hand(player_name: str, explicit_decision: bool = False) -> None:
         """Log when a player keeps their current hand."""
         if explicit_decision:
-            logger.info("No cards discarded; keeping current hand")
+            logger.info(f"{player_name} keeping current hand (explicit decision)")
         else:
             logger.info(f"{player_name} keeping current hand")


### PR DESCRIPTION
This PR introduces several improvements to the draw phase mechanics, enhances logging clarity, and fixes bugs related to card manipulation during the draw phase.

## Key Changes

### 1. Draw Phase Logic Improvements
- Fixed player iteration in `handle_draw_phase` to use `game.table` instead of `game.table.active_players()`
- Improved handling of discard indices by sorting them in descending order before removal
- Simplified card removal and addition logic by operating directly on the hand's cards list
- Added explicit handling for `None` return from `decide_discard`

### 2. Logging Enhancements
- Added player name to non-AI player logging messages for better traceability
- Improved "keep hand" logging to distinguish between explicit and implicit decisions
- Enhanced logging clarity throughout the draw phase

### 3. Test Coverage Expansion
- Added new test cases:
  - Exception handling during draw phase
  - Too many discards scenario
  - Exact cards needed scenario
  - None decision handling
- Improved mock setup for more realistic testing scenarios
- Added validation for log message ordering and counts

### 4. Bug Fixes
- Fixed card removal order bug by sorting indices in descending order
- Corrected in-place list modification issues during discard handling
- Fixed potential index out of range errors during card manipulation

## Technical Details

### Card Manipulation Changes
```python
# Old approach
discarded_cards = [player.hand.cards[idx] for idx in discard_indices]
player.hand.remove_cards(discard_indices)

# New approach
sorted_indices = sorted(discard_indices, reverse=True)
discarded_cards = []
for idx in sorted_indices:
    discarded_cards.append(player.hand.cards.pop(idx))
```

### Logging Improvements
```python
# Old
DrawLogger.log_non_ai_player()

# New
DrawLogger.log_non_ai_player(player.name)
```