### PR TITLE
Remove deprecated pot methods and commented-out code

### DIFF
--- a/data/states/game_state.py
+++ b/data/states/game_state.py
@@ -189,10 +189,6 @@ class GameState(BaseModel):
 
             player_states.append(player_state)
 
-            # Update the player with their new state
-            #! what is this for, why load state???
-            # player.update_from_state(player_state)
-
         # Create or update round state if needed
         if not hasattr(game, "round_state"):
             game.round_state = RoundState.new_round(game.round_number)

--- a/data/types/pot_types.py
+++ b/data/types/pot_types.py
@@ -16,13 +16,3 @@ class PotState(BaseModel):
     main_pot: int = 0
     side_pots: List[SidePot] = []
     total_pot: int = 0
-
-    def add_to_main_pot(self, amount: int) -> None:
-        """Add chips to the main pot."""
-        self.main_pot += amount
-        self.total_pot += amount
-
-    def add_side_pot(self, amount: int, players: List[str]) -> None:
-        """Create a new side pot."""
-        self.side_pots.append(SidePot(amount=amount, eligible_players=players))
-        self.total_pot += amount

--- a/game/game.py
+++ b/game/game.py
@@ -100,8 +100,8 @@ class AgenticPoker:
             raise ValueError("Players cannot have negative chips")
 
         #! make into betting class
-        self.current_bet = 0  # Add this line to initialize current_bet
-        self.pot = Pot()  #! change attr name to pot
+        self.current_bet = 0
+        self.pot = Pot()
 
         self.small_blind = self.config.small_blind
         self.big_blind = self.config.big_blind


### PR DESCRIPTION
- Deleted unused `add_to_main_pot()` and `add_side_pot()` methods from PotState
- Removed commented-out player state update code in game_state.py
- Cleaned up commented inline notes in game.py
- Simplified code by removing redundant or unnecessary comments and methods

The changes reduce code complexity and remove deprecated functionality across pot and game state management.