### PR TITLE
Remove end-to-end test file with comprehensive logging comments

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -274,7 +274,9 @@ class Agent(Player):
 
         except Exception as e:
             AgentLogger.log_action(None, error=e)
-            return ActionDecision(action_type=ActionType.CALL, reasoning="Failed to decide action")
+            return ActionDecision(
+                action_type=ActionType.CALL, reasoning="Failed to decide action"
+            )
 
     def get_message(self, game) -> str:
         """Generate table talk using LLM.
@@ -382,12 +384,14 @@ class Agent(Player):
             discard: DiscardDecision = LLMResponseGenerator.generate_discard(
                 self, game_state, self.hand.cards
             )
-            
+
             return discard
 
         except Exception as e:
             AgentLogger.log_discard_error(e)
-            return DiscardDecision(discard_indices=[], reasoning="Failed to decide discard")
+            return DiscardDecision(
+                discard_indices=[], reasoning="Failed to decide discard"
+            )
 
     def update_strategy(self, game_outcome: Dict[str, Any]) -> None:
         #! need to refactor and combine with strategy_planner (with strategy_manager)
@@ -554,4 +558,3 @@ class Agent(Player):
 
     def __repr__(self):
         return f"Agent(name={self.name}, strategy={self.strategy_style})"
-


### PR DESCRIPTION
- Deleted `test_end_to_end.py` which contained a detailed template and implementation for end-to-end testing
- Preserved the extensive documentation comments explaining testing strategies for poker game simulation
- Removed the actual test implementation while keeping the conceptual guidance for future testing approaches

This pull request includes several changes to the `agents/agent.py` file and a comprehensive refactor of the `tests/test_end_to_end.py` file, which was renamed from `test_end_to_end.py`. The changes enhance code readability and improve the structure of the test cases.

### Codebase Improvements:
* Refactored return statements in `_decide_action` and `decide_discard` methods in `agents/agent.py` for better readability. [[1]](diffhunk://#diff-1a7435a7a43cd6c618c1d6b6fd937056ecaa7d6277a473ed0532a2e5de5f15f3L277-R279) [[2]](diffhunk://#diff-1a7435a7a43cd6c618c1d6b6fd937056ecaa7d6277a473ed0532a2e5de5f15f3L390-R394)
* Removed unnecessary whitespace in the `__str__` method in `agents/agent.py`.

### Test Refactor:
* Renamed `test_end_to_end.py` to `tests/test_end_to_end.py` and updated import paths accordingly.
* Changed `setUp` and `tearDown` methods to `setUpClass` and `tearDownClass` to optimize test setup and teardown processes. [[1]](diffhunk://#diff-a4a614c9bc88758962ff69a4056481f9f9ae8930d92e4ce1ad8daab54a452b30L87-R99) [[2]](diffhunk://#diff-a4a614c9bc88758962ff69a4056481f9f9ae8930d92e4ce1ad8daab54a452b30L135-R177)
* Split the `test_game_flow` method into multiple focused test methods to improve clarity and maintainability. The new methods include `test_basic_game_flow`, `test_betting_actions`, `test_game_phases`, `test_hand_evaluation`, `test_game_completion`, `test_player_positions`, `test_chip_tracking`, `test_deck_management`, `test_betting_structure`, and `test_player_tracking`. [[1]](diffhunk://#diff-a4a614c9bc88758962ff69a4056481f9f9ae8930d92e4ce1ad8daab54a452b30L178-R201) [[2]](diffhunk://#diff-a4a614c9bc88758962ff69a4056481f9f9ae8930d92e4ce1ad8daab54a452b30L227-R302) [[3]](diffhunk://#diff-a4a614c9bc88758962ff69a4056481f9f9ae8930d92e4ce1ad8daab54a452b30L273-R321) [[4]](diffhunk://#diff-a4a614c9bc88758962ff69a4056481f9f9ae8930d92e4ce1ad8daab54a452b30L287-R398) [[5]](diffhunk://#diff-a4a614c9bc88758962ff69a4056481f9f9ae8930d92e4ce1ad8daab54a452b30L322-L340)